### PR TITLE
Default permissions annotations provided via KSP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+trim_trailing_whitespace = true
+max_line_length = 120

--- a/annotation-processor/build.gradle.kts
+++ b/annotation-processor/build.gradle.kts
@@ -4,8 +4,8 @@ val jvmVersion = JavaVersion.VERSION_17
 val kordVersion = "0.8.0-M15"
 
 plugins {
-	kotlin("jvm") version "1.7.10"
-	id("maven-publish")
+    kotlin("jvm") version "1.7.10"
+    id("maven-publish")
 }
 
 group = rootProject.group
@@ -13,68 +13,68 @@ version = rootProject.version
 java.sourceCompatibility = jvmVersion
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation(kotlin("stdlib"))
+    implementation(kotlin("stdlib"))
 
-	implementation("com.google.devtools.ksp:symbol-processing-api:1.7.10-1.0.6")
-	implementation("dev.kord:kord-core:$kordVersion")
+    implementation("com.google.devtools.ksp:symbol-processing-api:1.7.10-1.0.6")
+    implementation("dev.kord:kord-core:$kordVersion")
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		jvmTarget = jvmVersion.toString()
-		freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
-	}
+    kotlinOptions {
+        jvmTarget = jvmVersion.toString()
+        freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
+    }
 }
 
 val sourceJar = task("sourceJar", Jar::class) {
-	dependsOn(tasks["classes"])
-	archiveClassifier.set("sources")
-	from(sourceSets.main.get().allSource)
+    dependsOn(tasks["classes"])
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
 }
 
 publishing {
-	repositories {
-		maven {
-			url = if (project.version.toString().contains("SNAPSHOT")) {
-				uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
-			} else {
-				uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
-			}
-			credentials {
-				username = System.getenv("NEXUS_USER")
-				password = System.getenv("NEXUS_PASSWORD")
-			}
-		}
-	}
+    repositories {
+        maven {
+            url = if (project.version.toString().contains("SNAPSHOT")) {
+                uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
+            } else {
+                uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
+            }
+            credentials {
+                username = System.getenv("NEXUS_USER")
+                password = System.getenv("NEXUS_PASSWORD")
+            }
+        }
+    }
 
-	publications {
-		create<MavenPublication>("maven") {
-			pom {
-				name.set("KFox-Annotation-Processor")
-				description.set("Annotation processor for code generation with KFox")
-				url.set("https://github.com/ZeroTwo-Bot/KFox/")
+    publications {
+        create<MavenPublication>("maven") {
+            pom {
+                name.set("KFox-Annotation-Processor")
+                description.set("Annotation processor for code generation with KFox")
+                url.set("https://github.com/ZeroTwo-Bot/KFox/")
 
-				licenses {
-					license {
-						name.set("The Apache License, Version 2.0")
-						url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-					}
-				}
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
 
-				scm {
-					connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
-					developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
-					url.set("https://github.com/ZeroTwo-Bot/KFox/")
-				}
-			}
+                scm {
+                    connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
+                    developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
+                    url.set("https://github.com/ZeroTwo-Bot/KFox/")
+                }
+            }
 
-			from(components.getByName("java"))
+            from(components.getByName("java"))
 
-			artifact(sourceJar)
-		}
-	}
+            artifact(sourceJar)
+        }
+    }
 }

--- a/annotation-processor/build.gradle.kts
+++ b/annotation-processor/build.gradle.kts
@@ -1,0 +1,80 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+val jvmVersion = JavaVersion.VERSION_17
+val kordVersion = "0.8.0-M15"
+
+plugins {
+	kotlin("jvm") version "1.7.10"
+	id("maven-publish")
+}
+
+group = rootProject.group
+version = rootProject.version
+java.sourceCompatibility = jvmVersion
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation(kotlin("stdlib"))
+
+	implementation("com.google.devtools.ksp:symbol-processing-api:1.7.10-1.0.6")
+	implementation("dev.kord:kord-core:$kordVersion")
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		jvmTarget = jvmVersion.toString()
+		freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
+	}
+}
+
+val sourceJar = task("sourceJar", Jar::class) {
+	dependsOn(tasks["classes"])
+	archiveClassifier.set("sources")
+	from(sourceSets.main.get().allSource)
+}
+
+publishing {
+	repositories {
+		maven {
+			url = if (project.version.toString().contains("SNAPSHOT")) {
+				uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
+			} else {
+				uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
+			}
+			credentials {
+				username = System.getenv("NEXUS_USER")
+				password = System.getenv("NEXUS_PASSWORD")
+			}
+		}
+	}
+
+	publications {
+		create<MavenPublication>("maven") {
+			pom {
+				name.set("KFox-Annotation-Processor")
+				description.set("Annotation processor for code generation with KFox")
+				url.set("https://github.com/ZeroTwo-Bot/KFox/")
+
+				licenses {
+					license {
+						name.set("The Apache License, Version 2.0")
+						url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+					}
+				}
+
+				scm {
+					connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
+					developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
+					url.set("https://github.com/ZeroTwo-Bot/KFox/")
+				}
+			}
+
+			from(components.getByName("java"))
+
+			artifact(sourceJar)
+		}
+	}
+}

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/PermissionsProcessorProvider.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/PermissionsProcessorProvider.kt
@@ -6,6 +6,6 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import dev.bitflow.kfox.annotations.processor.permissions.PermissionsProcessor
 
 class PermissionsProcessorProvider : SymbolProcessorProvider {
-	override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
-		PermissionsProcessor(environment.codeGenerator, environment.logger)
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        PermissionsProcessor(environment.codeGenerator, environment.logger)
 }

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/PermissionsProcessorProvider.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/PermissionsProcessorProvider.kt
@@ -1,0 +1,11 @@
+package dev.bitflow.kfox.annotations.processor
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import dev.bitflow.kfox.annotations.processor.permissions.PermissionsProcessor
+
+class PermissionsProcessorProvider : SymbolProcessorProvider {
+	override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+		PermissionsProcessor(environment.codeGenerator, environment.logger)
+}

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
@@ -20,71 +20,71 @@ private const val ANNOTATION = "dev.bitflow.kfox.annotations.GenerateForPermissi
  * number. It could probably be an [Integer], but `DiscordBitSet` uses [Long]s, so we're using them here too.
  */
 class PermissionsProcessor(
-	private val generator: CodeGenerator,
-	private val logger: KSPLogger,
+    private val generator: CodeGenerator,
+    private val logger: KSPLogger,
 ) : SymbolProcessor {
-	override fun process(resolver: Resolver): List<KSAnnotated> {
-		// Find all annotated symbols
-		val symbols = resolver.getSymbolsWithAnnotation(ANNOTATION)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        // Find all annotated symbols
+        val symbols = resolver.getSymbolsWithAnnotation(ANNOTATION)
 
-		// Keep track of all symbols that KSP isn't able to validated (or resolve) right now
-		val ret = symbols.filter { !it.validate() }.toList()
+        // Keep track of all symbols that KSP isn't able to validated (or resolve) right now
+        val ret = symbols.filter { !it.validate() }.toList()
 
-		ret.forEach {
-			// Log each symbol that couldn't be validated
-			logger.warn("Unable to validate: $it")
-		}
+        ret.forEach {
+            // Log each symbol that couldn't be validated
+            logger.warn("Unable to validate: $it")
+        }
 
-		// Find all annotated class declarations that validate, and pass them through the `PermissionsVisitor`, which
-		// will process them individually.
-		symbols.filter { it is KSClassDeclaration && it.validate() }
-			.forEach { it.accept(PermissionsVisitor(), Unit) }
+        // Find all annotated class declarations that validate, and pass them through the `PermissionsVisitor`, which
+        // will process them individually.
+        symbols.filter { it is KSClassDeclaration && it.validate() }
+            .forEach { it.accept(PermissionsVisitor(), Unit) }
 
-		return ret
-	}
+        return ret
+    }
 
-	inner class PermissionsVisitor : KSVisitorVoid() {
-		override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
-			val permissions = Permission.values
+    inner class PermissionsVisitor : KSVisitorVoid() {
+        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
+            val permissions = Permission.values
 
-			// Create a new file that matches the file the class was defined within, appending `Annotations` to the
-			// filename before the `.kt` extension, which KSP fills in automatically.
-			val file = generator.createNewFile(
-				Dependencies(true, classDeclaration.containingFile!!),
-				classDeclaration.packageName.asString(),
-				classDeclaration.simpleName.asString() + "Annotations"
-			)
+            // Create a new file that matches the file the class was defined within, appending `Annotations` to the
+            // filename before the `.kt` extension, which KSP fills in automatically.
+            val file = generator.createNewFile(
+                Dependencies(true, classDeclaration.containingFile!!),
+                classDeclaration.packageName.asString(),
+                classDeclaration.simpleName.asString() + "Annotations"
+            )
 
-			file.write(
-				buildString {
-					// Generate the file header first, including the package declaration
-					appendLine(
-						"""
+            file.write(
+                buildString {
+                    // Generate the file header first, including the package declaration
+                    appendLine(
+                        """
                             package ${classDeclaration.packageName.asString()}
-                            
+
                             // Original annotation class, for safety
                             import ${classDeclaration.qualifiedName!!.asString()}
-                            
+
 						""".trimIndent()
-					)
+                    )
 
-					permissions
-						.sortedBy { it::class.simpleName }  // Makes logging more readable
-						.forEach {
-							logger.info("${it::class.simpleName} -> ${it.code.value}")
+                    permissions
+                        .sortedBy { it::class.simpleName }  // Makes logging more readable
+                        .forEach {
+                            logger.info("${it::class.simpleName} -> ${it.code.value}")
 
-							appendLine("// Permission: ${it::class.simpleName}")
-							appendLine("@${classDeclaration.simpleName.asString()}(${it.code.value})")
+                            appendLine("// Permission: ${it::class.simpleName}")
+                            appendLine("@${classDeclaration.simpleName.asString()}(${it.code.value})")
 
-							appendLine("@Target(AnnotationTarget.FUNCTION)")
-							appendLine("annotation class DefaultPermission${it::class.simpleName}")
+                            appendLine("@Target(AnnotationTarget.FUNCTION)")
+                            appendLine("annotation class DefaultPermission${it::class.simpleName}")
 
-							// Two extra blank lines, as is convention
-							appendLine("")
-							appendLine("")
-						}
-				}.encodeToByteArray()
-			)
-		}
-	}
+                            // Two extra blank lines, as is convention
+                            appendLine("")
+                            appendLine("")
+                        }
+                }.encodeToByteArray()
+            )
+        }
+    }
 }

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
@@ -1,0 +1,90 @@
+package dev.bitflow.kfox.annotations.processor.permissions
+
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.validate
+import dev.kord.common.entity.Permission
+
+private const val ANNOTATION = "dev.bitflow.kfox.annotations.GenerateForPermissions"
+
+/**
+ * Annotation processor that exists to generate annotations representing the various default permissions a command
+ * can have, allowing them to be set easily via a single annotation in your code.
+ *
+ * You really only ever want this to be run once per project, but there's nothing stopping you from using the
+ * GenerateForPermissions annotation, if you want that for some reason.
+ *
+ * The annotated annotation class must take exactly one parameter - a [Long] representing the permission bitfield
+ * number. It could probably be an [Integer], but `DiscordBitSet` uses [Long]s, so we're using them here too.
+ */
+class PermissionsProcessor(
+	private val generator: CodeGenerator,
+	private val logger: KSPLogger,
+) : SymbolProcessor {
+	override fun process(resolver: Resolver): List<KSAnnotated> {
+		// Find all annotated symbols
+		val symbols = resolver.getSymbolsWithAnnotation(ANNOTATION)
+
+		// Keep track of all symbols that KSP isn't able to validated (or resolve) right now
+		val ret = symbols.filter { !it.validate() }.toList()
+
+		ret.forEach {
+			// Log each symbol that couldn't be validated
+			logger.warn("Unable to validate: $it")
+		}
+
+		// Find all annotated class declarations that validate, and pass them through the `PermissionsVisitor`, which
+		// will process them individually.
+		symbols.filter { it is KSClassDeclaration && it.validate() }
+			.forEach { it.accept(PermissionsVisitor(), Unit) }
+
+		return ret
+	}
+
+	inner class PermissionsVisitor : KSVisitorVoid() {
+		override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
+			val permissions = Permission.values
+
+			// Create a new file that matches the file the class was defined within, appending `Annotations` to the
+			// filename before the `.kt` extension, which KSP fills in automatically.
+			val file = generator.createNewFile(
+				Dependencies(true, classDeclaration.containingFile!!),
+				classDeclaration.packageName.asString(),
+				classDeclaration.simpleName.asString() + "Annotations"
+			)
+
+			file.write(
+				buildString {
+					// Generate the file header first, including the package declaration
+					appendLine(
+						"""
+                            package ${classDeclaration.packageName.asString()}
+                            
+                            // Original annotation class, for safety
+                            import ${classDeclaration.qualifiedName!!.asString()}
+                            
+						""".trimIndent()
+					)
+
+					permissions
+						.sortedBy { it::class.simpleName }  // Makes logging more readable
+						.forEach {
+							logger.info("${it::class.simpleName} -> ${it.code.value}")
+
+							appendLine("// Permission: ${it::class.simpleName}")
+							appendLine("@${classDeclaration.simpleName.asString()}(${it.code.value})")
+
+							appendLine("@Target(AnnotationTarget.FUNCTION)")
+							appendLine("annotation class DefaultPermission${it::class.simpleName}")
+
+							// Two extra blank lines, as is convention
+							appendLine("")
+							appendLine("")
+						}
+				}.encodeToByteArray()
+			)
+		}
+	}
+}

--- a/annotation-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/annotation-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+dev.bitflow.kfox.annotations.processor.PermissionsProcessorProvider

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val jvmVersion = JavaVersion.VERSION_17
 
 plugins {
-	kotlin("jvm") version "1.7.10"
-	id("maven-publish")
+    kotlin("jvm") version "1.7.10"
+    id("maven-publish")
 }
 
 group = rootProject.group
@@ -12,65 +12,65 @@ version = rootProject.version
 java.sourceCompatibility = jvmVersion
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation(kotlin("stdlib"))
+    implementation(kotlin("stdlib"))
 }
 
 tasks.withType<KotlinCompile> {
-	kotlinOptions {
-		jvmTarget = jvmVersion.toString()
-		freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
-	}
+    kotlinOptions {
+        jvmTarget = jvmVersion.toString()
+        freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
+    }
 }
 
 val sourceJar = task("sourceJar", Jar::class) {
-	dependsOn(tasks["classes"])
-	archiveClassifier.set("sources")
-	from(sourceSets.main.get().allSource)
+    dependsOn(tasks["classes"])
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
 }
 
 publishing {
-	repositories {
-		maven {
-			url = if (project.version.toString().contains("SNAPSHOT")) {
-				uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
-			} else {
-				uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
-			}
-			credentials {
-				username = System.getenv("NEXUS_USER")
-				password = System.getenv("NEXUS_PASSWORD")
-			}
-		}
-	}
+    repositories {
+        maven {
+            url = if (project.version.toString().contains("SNAPSHOT")) {
+                uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
+            } else {
+                uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
+            }
+            credentials {
+                username = System.getenv("NEXUS_USER")
+                password = System.getenv("NEXUS_PASSWORD")
+            }
+        }
+    }
 
-	publications {
-		create<MavenPublication>("maven") {
-			pom {
-				name.set("KFox-Annotations")
-				description.set("Annotations for code generation with KFox")
-				url.set("https://github.com/ZeroTwo-Bot/KFox/")
+    publications {
+        create<MavenPublication>("maven") {
+            pom {
+                name.set("KFox-Annotations")
+                description.set("Annotations for code generation with KFox")
+                url.set("https://github.com/ZeroTwo-Bot/KFox/")
 
-				licenses {
-					license {
-						name.set("The Apache License, Version 2.0")
-						url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-					}
-				}
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
 
-				scm {
-					connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
-					developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
-					url.set("https://github.com/ZeroTwo-Bot/KFox/")
-				}
-			}
+                scm {
+                    connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
+                    developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
+                    url.set("https://github.com/ZeroTwo-Bot/KFox/")
+                }
+            }
 
-			from(components.getByName("java"))
+            from(components.getByName("java"))
 
-			artifact(sourceJar)
-		}
-	}
+            artifact(sourceJar)
+        }
+    }
 }

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -1,0 +1,76 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+val jvmVersion = JavaVersion.VERSION_17
+
+plugins {
+	kotlin("jvm") version "1.7.10"
+	id("maven-publish")
+}
+
+group = rootProject.group
+version = rootProject.version
+java.sourceCompatibility = jvmVersion
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation(kotlin("stdlib"))
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		jvmTarget = jvmVersion.toString()
+		freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
+	}
+}
+
+val sourceJar = task("sourceJar", Jar::class) {
+	dependsOn(tasks["classes"])
+	archiveClassifier.set("sources")
+	from(sourceSets.main.get().allSource)
+}
+
+publishing {
+	repositories {
+		maven {
+			url = if (project.version.toString().contains("SNAPSHOT")) {
+				uri("https://nexus.zerotwo.bot/repository/m2-public-snapshots/")
+			} else {
+				uri("https://nexus.zerotwo.bot/repository/m2-public-releases/")
+			}
+			credentials {
+				username = System.getenv("NEXUS_USER")
+				password = System.getenv("NEXUS_PASSWORD")
+			}
+		}
+	}
+
+	publications {
+		create<MavenPublication>("maven") {
+			pom {
+				name.set("KFox-Annotations")
+				description.set("Annotations for code generation with KFox")
+				url.set("https://github.com/ZeroTwo-Bot/KFox/")
+
+				licenses {
+					license {
+						name.set("The Apache License, Version 2.0")
+						url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+					}
+				}
+
+				scm {
+					connection.set("scm:git:git://github.com:ZeroTwo-Bot/KFox.git")
+					developerConnection.set("scm:git:ssh://github.com:ZeroTwo-Bot/KFox.git")
+					url.set("https://github.com/ZeroTwo-Bot/KFox/")
+				}
+			}
+
+			from(components.getByName("java"))
+
+			artifact(sourceJar)
+		}
+	}
+}

--- a/annotations/src/main/kotlin/dev/bitflow/kfox/annotations/GenerateForPermissions.kt
+++ b/annotations/src/main/kotlin/dev/bitflow/kfox/annotations/GenerateForPermissions.kt
@@ -1,0 +1,8 @@
+package dev.bitflow.kfox.annotations
+
+/**
+ * Generate annotations for default permissions based on Kord's built-in Permission type, applying the annotated
+ * annotation to them.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class GenerateForPermissions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,9 @@ val kordVersion = "0.8.0-M15"
 plugins {
     kotlin("jvm") version "1.7.10"
     kotlin("plugin.serialization") version "1.7.10"
+
     id("maven-publish")
+    id("com.google.devtools.ksp") version "1.7.10-1.0.6"
 }
 
 group = "dev.bitflow"
@@ -19,21 +21,25 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
+    implementation(project(":annotations"))
+
+    ksp(project(":annotation-processor"))
+
     api("org.reflections:reflections:0.10.2")
+    api("com.ibm.icu:icu4j:71.1")
+    api("dev.kord:kord-core:$kordVersion")
+
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.7.10")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
-    api("com.ibm.icu:icu4j:71.1")
 
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.23")
     runtimeOnly("org.slf4j:slf4j-api:1.7.36")
     runtimeOnly("ch.qos.logback:logback-classic:1.2.11")
     runtimeOnly("ch.qos.logback:logback-core:1.2.11")
-
-    api("dev.kord:kord-core:$kordVersion")
 
     testImplementation(kotlin("test"))
     testImplementation(platform("org.junit:junit-bom:5.8.2"))
@@ -61,7 +67,6 @@ val sourceJar = task("sourceJar", Jar::class) {
 }
 
 publishing {
-
     repositories {
         maven {
             url = if (project.version.toString().contains("SNAPSHOT")) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,4 @@
 rootProject.name = "kfox"
 
+include("annotations")
+include("annotation-processor")

--- a/src/main/kotlin/dev/bitflow/kfox/Annotations.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/Annotations.kt
@@ -1,9 +1,6 @@
 package dev.bitflow.kfox
 
-import dev.bitflow.kfox.filter.Filter
-import dev.bitflow.kfox.filter.GuildFilter
-import dev.kord.common.entity.Permission
-import dev.kord.common.entity.Permissions
+import dev.bitflow.kfox.annotations.GenerateForPermissions
 import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.FUNCTION)
@@ -62,4 +59,10 @@ annotation class ModalValue(
 @Target(AnnotationTarget.FUNCTION)
 annotation class Filter(
     vararg val filters: KClass<*>
+)
+
+@GenerateForPermissions
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class DefaultPermission(
+    val permission: Long
 )

--- a/src/main/kotlin/dev/bitflow/kfox/KFox.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/KFox.kt
@@ -4,7 +4,6 @@ import dev.bitflow.kfox.context.*
 import dev.bitflow.kfox.data.*
 import dev.bitflow.kfox.localization.ResourceBundleTranslationProvider
 import dev.bitflow.kfox.localization.TranslationProvider
-import dev.kord.common.DiscordBitSet
 import dev.kord.common.Locale
 import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.Choice
@@ -444,12 +443,11 @@ fun scanForCommands(translationProvider: TranslationProvider, reflections: Refle
             val defaultPermission = if (permissionAnnotations.isEmpty()) {
                 null
             } else {
-                Permissions {
-                    // So yeah, this is a massive hack, but Kord doesn't really give us a better option.
-                    permissionAnnotations.forEach {
-                        + Permission.Unknown(DiscordBitSet(it.permission))
+                Permissions(
+                    permissionAnnotations.map {
+                        Permission.Unknown(it.permission)
                     }
-                }
+                )
             }
 
             CommandData(

--- a/src/main/kotlin/dev/bitflow/kfox/KFox.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/KFox.kt
@@ -4,6 +4,7 @@ import dev.bitflow.kfox.context.*
 import dev.bitflow.kfox.data.*
 import dev.bitflow.kfox.localization.ResourceBundleTranslationProvider
 import dev.bitflow.kfox.localization.TranslationProvider
+import dev.kord.common.DiscordBitSet
 import dev.kord.common.Locale
 import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.Choice
@@ -437,6 +438,16 @@ fun scanForCommands(translationProvider: TranslationProvider, reflections: Refle
             val group = function.findAnnotation<Group>()
             val filters = function.findAnnotation<Filter>()
 
+            val defaultPermission = function.annotations
+                .mapNotNull { it.annotationClass.findAnnotation<DefaultPermission>() }
+                .firstOrNull()
+                ?.let {
+                    Permissions {
+                        // So yeah, this is a massive hack, but Kord doesn't really give us a better option.
+                        + Permission.Unknown(DiscordBitSet(it.permission))
+                    }
+                }
+
             CommandData(
                 translationProvider.getString(
                     annotation.nameKey,
@@ -503,7 +514,7 @@ fun scanForCommands(translationProvider: TranslationProvider, reflections: Refle
                     module = module
                 ),
                 emptyList(),
-                Permissions()
+                defaultPermission
             )
         }
 

--- a/src/main/kotlin/dev/bitflow/kfox/KFox.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/KFox.kt
@@ -437,7 +437,7 @@ fun scanForCommands(translationProvider: TranslationProvider, reflections: Refle
             val group = function.findAnnotation<Group>()
             val filters = function.findAnnotation<Filter>()
 
-            val permissionAnnotations =  function.annotations
+            val permissionAnnotations = function.annotations
                 .mapNotNull { it.annotationClass.findAnnotation<DefaultPermission>() }
 
             val defaultPermission = if (permissionAnnotations.isEmpty()) {

--- a/src/main/kotlin/dev/bitflow/kfox/KFox.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/KFox.kt
@@ -438,15 +438,19 @@ fun scanForCommands(translationProvider: TranslationProvider, reflections: Refle
             val group = function.findAnnotation<Group>()
             val filters = function.findAnnotation<Filter>()
 
-            val defaultPermission = function.annotations
+            val permissionAnnotations =  function.annotations
                 .mapNotNull { it.annotationClass.findAnnotation<DefaultPermission>() }
-                .firstOrNull()
-                ?.let {
-                    Permissions {
-                        // So yeah, this is a massive hack, but Kord doesn't really give us a better option.
+
+            val defaultPermission = if (permissionAnnotations.isEmpty()) {
+                null
+            } else {
+                Permissions {
+                    // So yeah, this is a massive hack, but Kord doesn't really give us a better option.
+                    permissionAnnotations.forEach {
                         + Permission.Unknown(DiscordBitSet(it.permission))
                     }
                 }
+            }
 
             CommandData(
                 translationProvider.getString(


### PR DESCRIPTION
This adds a set of annotations generated by KSP that allow you to specify the default permission required by a command.

This also supports defining multiple default permissions per command - just specify multiple annotations.

**Note:** The test bot currently does not compile, so I was unable to test whether this works.