### PR TITLE
Annotations for command argument options

### DIFF
--- a/annotation-processor/build.gradle.kts
+++ b/annotation-processor/build.gradle.kts
@@ -17,6 +17,7 @@ repositories {
 }
 
 dependencies {
+    implementation(kotlin("reflect"))
     implementation(kotlin("stdlib"))
 
     implementation("com.google.devtools.ksp:symbol-processing-api:1.7.10-1.0.6")

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/ChannelTypesProcessorProvider.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/ChannelTypesProcessorProvider.kt
@@ -1,0 +1,11 @@
+package dev.bitflow.kfox.annotations.processor
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import dev.bitflow.kfox.annotations.processor.channels.ChannelTypesProcessor
+
+class ChannelTypesProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        ChannelTypesProcessor(environment.codeGenerator, environment.logger)
+}

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/channels/ChannelTypesProcessor.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/channels/ChannelTypesProcessor.kt
@@ -1,0 +1,91 @@
+package dev.bitflow.kfox.annotations.processor.channels
+
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.validate
+import dev.kord.common.entity.ChannelType
+
+private const val ANNOTATION = "dev.bitflow.kfox.annotations.GenerateForChannelTypes"
+
+/**
+ * Annotation processor that exists to generate annotations representing the various channel types a channel command
+ * option can require, allowing them to be set easily via a single annotation in your code.
+ *
+ * You really only ever want this to be run once per project, but there's nothing stopping you from using the
+ * GenerateForChannelTypes annotation twice, if you want that for some reason.
+ *
+ * The annotated annotation class must take exactly one parameter - an [Int] representing the channel type enum value.
+ */
+class ChannelTypesProcessor(
+    private val generator: CodeGenerator,
+    private val logger: KSPLogger,
+) : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        // Find all annotated symbols
+        val symbols = resolver.getSymbolsWithAnnotation(ANNOTATION)
+
+        // Keep track of all symbols that KSP isn't able to validated (or resolve) right now
+        val ret = symbols.filter { !it.validate() }.toList()
+
+        ret.forEach {
+            // Log each symbol that couldn't be validated
+            logger.warn("Unable to validate: $it")
+        }
+
+        // Find all annotated class declarations that validate, and pass them through the `ChannelTypesVisitor`, which
+        // will process them individually.
+        symbols.filter { it is KSClassDeclaration && it.validate() }
+            .forEach { it.accept(ChannelTypesVisitor(), Unit) }
+
+        return ret
+    }
+
+    inner class ChannelTypesVisitor : KSVisitorVoid() {
+        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
+            val channelTypes = ChannelType::class.sealedSubclasses  // Get all sealed subtypes
+                .mapNotNull { it.objectInstance }  // Filter and map to only those that are `object`s
+                .filter { it::class.annotations.filterIsInstance<Deprecated>().isEmpty() }  // Filter out deprecations
+
+            // Create a new file that matches the file the class was defined within, appending `Annotations` to the
+            // filename before the `.kt` extension, which KSP fills in automatically.
+            val file = generator.createNewFile(
+                Dependencies(true, classDeclaration.containingFile!!),
+                classDeclaration.packageName.asString(),
+                classDeclaration.simpleName.asString() + "Annotations"
+            )
+
+            file.write(
+                buildString {
+                    // Generate the file header first, including the package declaration
+                    appendLine(
+                        """
+                            package ${classDeclaration.packageName.asString()}
+
+                            // Original annotation class, for safety
+                            import ${classDeclaration.qualifiedName!!.asString()}
+
+						""".trimIndent()
+                    )
+
+                    channelTypes
+                        .sortedBy { it::class.simpleName }  // Makes logging more readable
+                        .forEach {
+                            logger.info("${it::class.simpleName} -> ${it.value}")
+
+                            appendLine("// Channel Type: ${it::class.simpleName}")
+                            appendLine("@${classDeclaration.simpleName.asString()}(${it.value})")
+
+                            appendLine("@Target(AnnotationTarget.VALUE_PARAMETER)")
+                            appendLine("annotation class ChannelType${it::class.simpleName}")
+
+                            // Two extra blank lines, as is convention
+                            appendLine("")
+                            appendLine("")
+                        }
+                }.encodeToByteArray()
+            )
+        }
+    }
+}

--- a/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
+++ b/annotation-processor/src/main/kotlin/dev/bitflow/kfox/annotations/processor/permissions/PermissionsProcessor.kt
@@ -14,7 +14,7 @@ private const val ANNOTATION = "dev.bitflow.kfox.annotations.GenerateForPermissi
  * can have, allowing them to be set easily via a single annotation in your code.
  *
  * You really only ever want this to be run once per project, but there's nothing stopping you from using the
- * GenerateForPermissions annotation, if you want that for some reason.
+ * GenerateForPermissions annotation twice, if you want that for some reason.
  *
  * The annotated annotation class must take exactly one parameter - a [Long] representing the permission bitfield
  * number. It could probably be an [Integer], but `DiscordBitSet` uses [Long]s, so we're using them here too.

--- a/annotation-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/annotation-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,1 +1,2 @@
+dev.bitflow.kfox.annotations.processor.ChannelTypesProcessorProvider
 dev.bitflow.kfox.annotations.processor.PermissionsProcessorProvider

--- a/annotations/src/main/kotlin/dev/bitflow/kfox/annotations/GenerateForChannelTypes.kt
+++ b/annotations/src/main/kotlin/dev/bitflow/kfox/annotations/GenerateForChannelTypes.kt
@@ -1,0 +1,8 @@
+package dev.bitflow.kfox.annotations
+
+/**
+ * Generate annotations for required channel types based on Kord's built-in ChannelType type, applying the annotated
+ * annotation to them.
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class GenerateForChannelTypes

--- a/src/main/kotlin/dev/bitflow/kfox/Annotations.kt
+++ b/src/main/kotlin/dev/bitflow/kfox/Annotations.kt
@@ -1,5 +1,6 @@
 package dev.bitflow.kfox
 
+import dev.bitflow.kfox.annotations.GenerateForChannelTypes
 import dev.bitflow.kfox.annotations.GenerateForPermissions
 import kotlin.reflect.KClass
 
@@ -63,6 +64,30 @@ annotation class Filter(
 
 @GenerateForPermissions
 @Target(AnnotationTarget.ANNOTATION_CLASS)
-annotation class DefaultPermission(
+internal annotation class DefaultPermission(
     val permission: Long
+)
+
+@GenerateForChannelTypes
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+internal annotation class ChannelType(
+    val channelType: Int
+)
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class LongOptions(
+    val min: Long = Long.MIN_VALUE,
+    val max: Long = Long.MAX_VALUE
+)
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class DoubleOptions(
+    val min: Double = Double.MIN_VALUE,
+    val max: Double = Double.MAX_VALUE
+)
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class StringOptions(
+    val minLength: Int = Int.MIN_VALUE,
+    val maxLength: Int = Int.MAX_VALUE
 )


### PR DESCRIPTION
**Note:** The test bot still doesn't compile, so I don't have a way to test this. Make sure you do!

This adds the following annotations for use directly on the function parameters that represent command arguments:

* A set of generated `ChannelType` annotations (and an annotation processor for them), which you can use to specify (one or more) channel types that Discord should filter to in the client - additionally, annotations are not generated for deprecated channel types
* `DoubleOptions` for `Double`-typed arguments, with `max` and `min` options
* `LongOptions` for `Long`-typed arguments, with `max` and `min` options
* `StringOptions` for `String`-typed arguments, with `max` and `min` options

I've also updated the option registration logic slightly - you were using `number` for all numeric arguments, but this will always give you a `Double`. I've correctly registered `int` and `number` options for `Long` and `Double` types respectively, as this is all Discord supports.